### PR TITLE
Cargo fuzz documentation correction

### DIFF
--- a/detectors/cargo-fuzz/README.md
+++ b/detectors/cargo-fuzz/README.md
@@ -33,7 +33,7 @@ $ cd integer-overflow-or-underflow
 3. Run one of the fuzz targets, for example:
 
 ```sh
-$ cargo fuzz run fuzz_add_overflows
+$ cargo fuzz run fuzz-add-overflows
 ```
 
 ## References


### PR DESCRIPTION
Correction in `cargo-fuzz` documentation. Step 3 has a typo: `cargo fuzz run fuzz_add_overflows`. The correct command is with dashes instead of underscores `cargo fuzz run fuzz-add-overflows`